### PR TITLE
Improve deletion of unused PAT keys on mac devices

### DIFF
--- a/config/keyring_darwin.go
+++ b/config/keyring_darwin.go
@@ -12,8 +12,8 @@ import (
 
 // SetGitCredential directly overwrites the keychain entry that Git's osxkeychain helper reads.
 func SetGitCredential(username, token string) error {
-	// Attempt to delete any existing password for this account/server combination first.
-	_ = exec.Command("security", "delete-internet-password", "-a", username, "-s", "github.com").Run()
+	// Attempt to delete ALL existing password for github.com first.
+	_ = exec.Command("security", "delete-internet-password", "-s", "github.com").Run()
 
 	// Add the new password.
 	cmd := exec.Command(


### PR DESCRIPTION
- (Darwin only) Modified PAT related key deletion logic to prevent key duplication;  all `github.com` keys are deleted when switching PAT.

#### Side Notes
- Unused PAT cleaning logic is missing for some commands (e.g. `gitego rm`). There could be duplicated instances of the `github.com` key, causing accidents in using the wrong identity.
- Existing design expects a single `github.com` key anyway.